### PR TITLE
修改日志时区和漫画签到日志

### DIFF
--- a/src/main/java/org/example/MangaTask.java
+++ b/src/main/java/org/example/MangaTask.java
@@ -17,10 +17,11 @@ public class MangaTask {
             JSONObject jsonObject = function.mangaClockIn("android");
             if("0".equals(jsonObject.getString("code"))){
                 LOGGER.info("漫画签到成功"+"-------->"+jsonObject);
-            }
-            else{
-                LOGGER.warn("漫画签到失败"+"-------->"+jsonObject);
-            }
+            }else if("clockin clockin is duplicate".equals(jsonObject.getString("msg"))){
+                LOGGER.info("漫画已经签到过了"+"-------->"+jsonObject);
+            }else{
+				LOGGER.warn("漫画签到失败"+"-------->"+jsonObject);
+			}
         } catch (Exception e){
             LOGGER.error("漫画签到失败"+"-------->"+e);
         }

--- a/src/main/java/org/example/Request.java
+++ b/src/main/java/org/example/Request.java
@@ -75,6 +75,22 @@ public class Request {
         writer.close();
 
         int responseCode = connection.getResponseCode();
+        InputStream inputStream = null;
+        if(responseCode < 400){
+            //得到正确的响应流
+            inputStream = connection.getInputStream();
+        }else{
+            //得到错误的响应流
+            inputStream = connection.getErrorStream();
+        }
+        
+        //将响应流转换成字符串
+        String result = new Scanner(inputStream).useDelimiter("\\Z").next();//将流转换为字符串。
+        JSONObject jsonObject = JSON.parseObject(result);
+        inputStream.close();
+        return jsonObject;
+        
+		/*
         if(responseCode == HttpURLConnection.HTTP_OK){
             //得到响应流
             InputStream inputStream = connection.getInputStream();
@@ -86,6 +102,6 @@ public class Request {
         }
         else{
             return JSONObject.parseObject("");
-        }
+        }*/
     }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
         说白了就是设置静态属性，
         后面使用的时候直接用${name}即可。
      -->
-    <property name="pattern" value="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} %c %M %L %thread %m%n">
+    <property name="pattern" value="[%-5level] %date{yyyy-MM-dd HH:mm:ss.SSS,GMT+8} %c %M %L %thread %m%n">
         <!--
         日志输出格式：
             %-5level 日志级别

--- a/target/classes/logback.xml
+++ b/target/classes/logback.xml
@@ -5,7 +5,7 @@
         说白了就是设置静态属性，
         后面使用的时候直接用${name}即可。
      -->
-    <property name="pattern" value="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} %c %M %L %thread %m%n">
+    <property name="pattern" value="[%-5level] %date{yyyy-MM-dd HH:mm:ss.SSS,GMT+8} %c %M %L %thread %m%n">
         <!--
         日志输出格式：
             %-5level 日志级别


### PR DESCRIPTION
1. 将日志时区改为东八区即北京时间增加对国人的可读性
2. 将漫画重复签到的日志改为"漫画已经签到过了"并输出json值。(修改前因为重复签到产生的responseCode不为HttpURLConnection.HTTP_OK即整数200，直接返回了空字符的·json对象即null，并抛出java.lang.NullPointerException异常，实际上服务器返回了json数据的需要做接收处理而不是直接返回null，我修改了post方法对responseCode的判断)

虽然responseCode不为200但正常返回json数据的情况很罕见，但即使出现异常的http状态码服务器也可能返回有用的信息，虽然一般情况下可以忽略这种罕见情况但这个漫画的签到接口正好遇上了。